### PR TITLE
Solve WiFi.status() not updating bug

### DIFF
--- a/examples/RTL8720_WiFi/RTL8720_WiFi.ino
+++ b/examples/RTL8720_WiFi/RTL8720_WiFi.ino
@@ -159,7 +159,7 @@ void loop()
 {
   WiFiManager->run();
   check_status();
-
+  delay(1000);
 #if USE_DYNAMIC_PARAMETERS
   displayCredentialsInLoop();
 #endif


### PR DESCRIPTION
Added line 162 `delay(1000);`

## Details
The previous bug was caused by the high priority of the RTOS `main()` task blocking the WiFi status from updating.
Adding a delay could avoid this task. 
Upon Wi-Fi is disconnected, a ROM message: `RTL8721D[Driver]: no beacon for a long time, disconnect or roaming` will be shown in the log. 
Attached is the debugging log and returned `WiFi.status()` details for your reference: https://paste.ofcode.org/rnyEnrhcDSPk9NEu2a274e

```
typedef enum {
    WL_NO_SHIELD = 255,
    WL_IDLE_STATUS = 0,
    WL_NO_SSID_AVAIL,     // 1
    WL_SCAN_COMPLETED,    // 2
    WL_CONNECTED,         // 3
    WL_CONNECT_FAILED,    // 4
    WL_CONNECTION_LOST,   // 5
    WL_DISCONNECTED       // 6
} wl_status_t;
```

Thank you.